### PR TITLE
Fix headlines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 Here you can open issues for [Ionic View](http://docs.ionic.io/tools/view/).
 
-##Common Issues
+## Common Issues
 
-####App loading blank or white screen on load?
+#### App loading blank or white screen on load?
 First [check if the plugin you're using is supported by View](http://docs.ionic.io/tools/view/#supported-plugins)
 
 If it's not and you would like to see it supported, [request to have it added](https://github.com/driftyco/ionic-view-issues/issues/15).
-
-===== 


### PR DESCRIPTION
Github changed markdown parser, headlines need spaces after ## now.